### PR TITLE
Represent timestamps as timestamp_t, and a few other small changes

### DIFF
--- a/bst/node.h
+++ b/bst/node.h
@@ -42,7 +42,9 @@ namespace bst_ns {
         Node() {}
         Node(const Node& node) {}
 
-        friend ostream& operator<<(ostream& os, const Node<K,V>& obj) {}
+        friend ostream& operator<<(ostream& os, const Node<K,V>& obj) {
+            return os;
+        }
         void printTreeFile(ostream& os) {}
         void printTreeFileWeight(ostream& os, set< Node<K,V>* > *seen) {}
         void printTreeFileWeight(ostream& os) {}

--- a/rq/rq_rwlock.h
+++ b/rq/rq_rwlock.h
@@ -43,7 +43,7 @@ private:
         {
             struct
             { // anonymous struct inside anonymous union means we don't need to type anything special to access these variables
-                long long rq_lin_time;
+                timestamp_t rq_lin_time;
                 HashList<K> *hashlist;
                 volatile char padding0[PREFETCH_SIZE_BYTES];
                 void *announcements[MAX_NODES_INSERTED_OR_DELETED_ATOMICALLY + 1];
@@ -98,7 +98,7 @@ public:
         DEBUG_DEINIT_RQPROVIDER(NUM_PROCESSES);
     }
 
-    long long debug_getTimestamp()
+    timestamp_t debug_getTimestamp()
     {
         return ts_provider.Read();
     }
@@ -211,7 +211,7 @@ public:
 private:
     inline void set_insertion_timestamps(
         const int tid,
-        const long long ts,
+        const timestamp_t ts,
         NodeType *const *const insertedNodes,
         NodeType *const *const deletedNodes)
     {
@@ -226,7 +226,7 @@ private:
 
     inline void set_deletion_timestamps(
         const int tid,
-        const long long ts,
+        const timestamp_t ts,
         NodeType *const *const insertedNodes,
         NodeType *const *const deletedNodes)
     {
@@ -259,7 +259,7 @@ public:
         }
 
         rwlock.readLock();
-        long long ts = ts_provider.Read();
+        timestamp_t ts = ts_provider.Read();
         *lin_addr = lin_newval; // original linearization point
         rwlock.readUnlock();
 
@@ -297,7 +297,7 @@ public:
         }
 
         rwlock.readLock();
-        long long ts = ts_provider.Read();
+        timestamp_t ts = ts_provider.Read();
         T res = __sync_val_compare_and_swap(lin_addr, lin_oldval, lin_newval);
         rwlock.readUnlock();
 
@@ -366,7 +366,7 @@ private:
         // we return asap, and list facts that must be true if we didn't return
         assert(foundDuringTraversal || !logicalDeletion || ds->isLogicallyDeleted(tid, node));
 
-        long long itime = TIMESTAMP_NOT_SET;
+        timestamp_t itime = TIMESTAMP_NOT_SET;
         while (itime == TIMESTAMP_NOT_SET)
         {
             itime = node->itime;
@@ -382,7 +382,7 @@ private:
         // fact: node was inserted before the range query
 
         bool logicallyDeleted = (logicalDeletion && ds->isLogicallyDeleted(tid, node));
-        long long dtime = TIMESTAMP_NOT_SET;
+        timestamp_t dtime = TIMESTAMP_NOT_SET;
 
         if (!logicalDeletion && foundDuringTraversal)
             goto tryAddToRQ; // no logical deletion. since node was inserted before the range query, and the traversal encountered it, it must have been deleted AFTER the traversal encountered it.
@@ -558,7 +558,7 @@ public:
 #endif
 
         SOFTWARE_BARRIER;
-        long long end_timestamp = ts_provider.Read();
+        timestamp_t end_timestamp = ts_provider.Read();
         SOFTWARE_BARRIER;
 
         int numVisitedInAnnouncements = 0;
@@ -628,7 +628,7 @@ public:
 
                 ++numVisitedInEpochBags;
 
-                long long dtime = node->dtime;
+                timestamp_t dtime = node->dtime;
                 if (dtime != TIMESTAMP_NOT_SET && dtime > end_timestamp)
                 {
 

--- a/rq/rq_vcas.h
+++ b/rq/rq_vcas.h
@@ -302,7 +302,7 @@ class RQProvider {
       }
     }
 
-    return NULL;
+    return static_cast<T>(NULL);
   }
 
   // invoke at the start of each traversal

--- a/rq/timestamp_provider.h
+++ b/rq/timestamp_provider.h
@@ -25,7 +25,7 @@ class TimestampProvider {
 class RdtscTimestamp: public TimestampProvider {
     private:
         inline timestamp_t readRdtsc() {
-            unsigned long long cycles_low, cycles_high;
+            timestamp_t cycles_low, cycles_high;
             asm volatile (
                 "CPUID\n\t" // waits for previous code to finish executing 
                 "RDTSC\n\t" // reads timestamp and stores in registers rdx and rax
@@ -48,7 +48,7 @@ class RdtscTimestamp: public TimestampProvider {
 class RdtscpTimestamp: public TimestampProvider {
     private:
         inline timestamp_t readRdtscp() {
-            unsigned long long cycles_low, cycles_high;
+            timestamp_t cycles_low, cycles_high;
             asm volatile (
                 "RDTSCP\n\t"
                 "mov %%rdx, %0\n\t"
@@ -153,7 +153,7 @@ class BundlingTimestamp: public TimestampProvider {
 // lock-based implementation of ebr timestamp
 class EbrTimestamp: public TimestampProvider {
     private:
-        volatile long long timestamp;
+        volatile timestamp_t timestamp;
 
     public:
         EbrTimestamp() {

--- a/vcas_bst/vcas_bst.h
+++ b/vcas_bst/vcas_bst.h
@@ -285,7 +285,7 @@ public:
             return true;
         }
 
-        inline int getKeys(const int tid, Node<K,V> * node, K * const outputKeys, V * const outputValues, const long long ts) {
+        inline int getKeys(const int tid, Node<K,V> * node, K * const outputKeys, V * const outputValues, const timestamp_t ts) {
             if (rqProvider->read_addr(tid, &node->left, ts) == NULL && node->key != NO_KEY) {
                 // leaf ==> its key is in the set.
                 outputKeys[0] = node->key;

--- a/vcas_bst/vcas_bst_impl.h
+++ b/vcas_bst/vcas_bst_impl.h
@@ -71,7 +71,7 @@ template<class K, class V, class Compare, class RecManager>
 int vcas_bst_ns::vcas_bst<K,V,Compare,RecManager>::rangeQuery(const int tid, const K& lo, const K& hi, K * const resultKeys, V * const resultValues) {
     block<Node<K,V> > stack (NULL);
     recmgr->leaveQuiescentState(tid, true);
-    long long ts = rqProvider->traversal_start(tid);
+    timestamp_t ts = rqProvider->traversal_start(tid);
     // volatile long long sum = 0;
     // for(int i = 0; i < 500000; i++)
     //     sum += i;

--- a/vcas_bst/vcas_node.h
+++ b/vcas_bst/vcas_node.h
@@ -33,7 +33,7 @@ namespace vcas_bst_ns {
         nodeptr right;
         RECLAIM_RCU_RCUHEAD_DEFN;
 
-        volatile long long ts;
+        volatile timestamp_t ts;
         nodeptr nextv;
 
         Node() {}

--- a/vcas_bst/vcas_node.h
+++ b/vcas_bst/vcas_node.h
@@ -39,7 +39,9 @@ namespace vcas_bst_ns {
         Node() {}
         Node(const Node& node) {}
 
-        friend ostream& operator<<(ostream& os, const Node<K,V>& obj) {}
+        friend ostream& operator<<(ostream& os, const Node<K,V>& obj) {
+            return os;
+        }
         void printTreeFile(ostream& os) {}
         void printTreeFileWeight(ostream& os, set< Node<K,V>* > *seen) {}
         void printTreeFileWeight(ostream& os) {}

--- a/vcas_citrus/vcas_citrus.h
+++ b/vcas_citrus/vcas_citrus.h
@@ -119,7 +119,7 @@ class citrustree {
   inline bool isLogicallyInserted(const int tid, nodeptr node) { return true; }
 
   inline int getKeys(const int tid, node_t<K, V>* node, K* const outputKeys,
-                     V* const outputValues, long long ts) {
+                     V* const outputValues, timestamp_t ts) {
     if (node->key >= NO_KEY) return 0;
     outputKeys[0] = node->key;
     outputValues[0] = node->value;

--- a/vcas_citrus/vcas_citrus_impl.h
+++ b/vcas_citrus/vcas_citrus_impl.h
@@ -421,7 +421,7 @@ int citrustree<K, V, RecManager>::rangeQuery(const int tid, const K& lo,
                                              V* const resultValues) {
   block<node_t<K, V> > stack(NULL);
   recordmgr->leaveQuiescentState(tid, true);
-  long long ts = rqProvider->traversal_start(tid);
+  timestamp_t ts = rqProvider->traversal_start(tid);
 
   // depth first traversal (of interesting subtrees)
   int size = 0;

--- a/vcas_lazylist/vcas_lazylist.h
+++ b/vcas_lazylist/vcas_lazylist.h
@@ -105,7 +105,7 @@ class lazylist {
 
   //+ Integrate timestamp for vCAS
   inline int getKeys(const int tid, node_t<K, V> *node, K *const outputKeys,
-                     V *const outputValues, int ts) {
+                     V *const outputValues, timestamp_t ts) {
     // ignore marked
     outputKeys[0] = node->key;
     outputValues[0] = node->val;

--- a/vcas_lazylist/vcas_lazylist_impl.h
+++ b/vcas_lazylist/vcas_lazylist_impl.h
@@ -287,7 +287,7 @@ int lazylist<K, V, RecManager>::rangeQuery(const int tid, const K &lo,
                                            const K &hi, K *const resultKeys,
                                            V *const resultValues) {
   recordmgr->leaveQuiescentState(tid, true);
-  int ts = rqProvider->traversal_start(tid);
+  timestamp_t ts = rqProvider->traversal_start(tid);
   int cnt = 0;
   nodeptr prev;
   nodeptr curr = rqProvider->read_vcas(tid, head->next, ts);

--- a/vcas_skiplist_lock/vcas_skiplist_lock.h
+++ b/vcas_skiplist_lock/vcas_skiplist_lock.h
@@ -149,7 +149,7 @@ class skiplist {
   RecManager* const debugGetRecMgr() { return recmgr; }
 
   inline int getKeys(const int tid, node_t<K, V>* node, K* const outputKeys,
-                     V* const outputValues, const int ts) {
+                     V* const outputValues, const timestamp_t ts) {
     outputKeys[0] = node->key;
     outputValues[0] = node->val;
     return 1;

--- a/vcas_skiplist_lock/vcas_skiplist_lock_impl.h
+++ b/vcas_skiplist_lock/vcas_skiplist_lock_impl.h
@@ -481,7 +481,7 @@ int skiplist<K, V, RecManager>::rangeQuery(const int tid, const K& lo,
                                            V* const resultValues) {
   //    cout<<"rangeQuery(lo="<<lo<<" hi="<<hi<<")"<<endl;
   recmgr->leaveQuiescentState(tid, true);
-  int ts = rqProvider->traversal_start(tid);
+  timestamp_t ts = rqProvider->traversal_start(tid);
   int cnt = 0;
   // use the find function to find the low key
   //    int nodesSkipped = 0;


### PR DESCRIPTION
I have gone through the vcas_bst/ folder and made sure timestamps are represented as timestamp_t.

Additionally, I have gone through the rq/ folder, and for every range query provider that uses a templated timestamp provider, I made sure they also consistently represent timestamps as timestamp_t. Affected providers were rq_vcas, rq_rwlock, and rq_lockfree_hq.

I made a few other minor improvements in the process. I addressed a few compiler warnings to make builds less noisy, and enhanced plot.py so that it is able to render multiple range query rates at once.